### PR TITLE
t_mod_New - Fixes for running `configure` outside of the root directory

### DIFF
--- a/configure
+++ b/configure
@@ -1823,8 +1823,7 @@ cat conftest.log >> config.log
 cat conftest.log
 
 [ "$SRCPATH" != "." ] && ln -sf ${SRCPATH}/Makefile ./Makefile
-mkdir -p common/{aarch64,arm,mips,ppc,x86} encoder extras filters/video input output tools
+mkdir -p audio/encoders common/{aarch64,arm,mips,ppc,x86} encoder extras filters/{audio,video} input/audio output tools
 
 echo
 echo "You can run 'make' or 'make fprofiled' now."
-

--- a/version.sh
+++ b/version.sh
@@ -38,5 +38,5 @@ else
     VER="x [${BIT_DEPTH}-bit@${CHROMA_FORMATS} ${BUILD_ARCH}]"
 fi
 rm -f config.git-hash
-API=`grep '#define X264_BUILD' < x264.h | sed -e 's/.* \([1-9][0-9]*\).*/\1/'`
+API=`grep '#define X264_BUILD' < "$(dirname "$0")"/x264.h | sed -e 's/.* \([1-9][0-9]*\).*/\1/'`
 echo "#define X264_POINTVER \"0.$API.$VER\""


### PR DESCRIPTION
Hi, I noticed that `version.sh` does not correctly parse the API version from `x264.h` when `configure`ing from outside the project root directory. I'm not sure how you apply patches and everything to vanilla x264 but here is a small fix :).

Edit: Also discovered some directories weren't getting made as another side effect of `configure`ing outside of the root directory.