### PR TITLE
i_avcintra_class replaced by avcintra_hd & avc_intra_4k

### DIFF
--- a/common/tables.h
+++ b/common/tables.h
@@ -63,6 +63,9 @@ extern const uint8_t x264_cqm_avci100_720p_8iy[64];
 extern const uint8_t x264_cqm_avci100_1080_4ic[16];
 extern const uint8_t x264_cqm_avci100_1080i_8iy[64];
 extern const uint8_t x264_cqm_avci100_1080p_8iy[64];
+extern const uint8_t x264_cqm_avci300_2160p_4iy[16];
+extern const uint8_t x264_cqm_avci300_2160p_4ic[16];
+extern const uint8_t x264_cqm_avci300_2160p_8iy[64];
 
 extern const uint8_t x264_decimate_table4[16];
 extern const uint8_t x264_decimate_table8[64];

--- a/encoder/set.c
+++ b/encoder/set.c
@@ -241,7 +241,8 @@ void x264_sps_init( x264_sps_t *sps, int i_id, x264_param_t *param )
         sps->vui.i_log2_max_mv_length_vertical = (int)log2f( X264_MAX( 1, param->analyse.i_mv_range*4-1 ) ) + 1;
     }
 
-    sps->b_avcintra = !!param->i_avcintra_class;
+    sps->b_avcintra_4k =  param->i_avcintra_class > 200;
+    sps->b_avcintra_hd =  !!(param->i_avcintra_class && param->i_avcintra_class < 300);
     sps->i_cqm_preset = param->i_cqm_preset;
 }
 
@@ -325,8 +326,8 @@ void x264_sps_write( bs_t *s, x264_sps_t *sps )
         bs_write_ue( s, BIT_DEPTH-8 ); // bit_depth_chroma_minus8
         bs_write1( s, sps->b_qpprime_y_zero_transform_bypass );
         /* Exactly match the AVC-Intra bitstream */
-        bs_write1( s, sps->b_avcintra ); // seq_scaling_matrix_present_flag
-        if( sps->b_avcintra )
+        bs_write1( s, sps->b_avcintra_hd ); // seq_scaling_matrix_present_flag
+        if( sps->b_avcintra_hd )
         {
             scaling_list_write( s, sps, CQM_4IY );
             scaling_list_write( s, sps, CQM_4IC );
@@ -524,7 +525,7 @@ void x264_pps_write( bs_t *s, x264_sps_t *sps, x264_pps_t *pps )
     bs_write1( s, pps->b_constrained_intra_pred );
     bs_write1( s, pps->b_redundant_pic_cnt );
 
-    int b_scaling_list = !sps->b_avcintra && sps->i_cqm_preset != X264_CQM_FLAT;
+    int b_scaling_list = !sps->b_avcintra_hd && sps->i_cqm_preset != X264_CQM_FLAT;
     if( pps->b_transform_8x8_mode || b_scaling_list )
     {
         bs_write1( s, pps->b_transform_8x8_mode );
@@ -533,14 +534,27 @@ void x264_pps_write( bs_t *s, x264_sps_t *sps, x264_pps_t *pps )
         {
             scaling_list_write( s, sps, CQM_4IY );
             scaling_list_write( s, sps, CQM_4IC );
-            bs_write1( s, 0 ); // Cr = Cb
-            scaling_list_write( s, sps, CQM_4PY );
-            scaling_list_write( s, sps, CQM_4PC );
-            bs_write1( s, 0 ); // Cr = Cb
+            if( sps->b_avcintra_4k )
+            {
+                scaling_list_write( s, sps, CQM_4IC );
+                bs_write1( s, 0 ); // no inter
+                bs_write1( s, 0 ); // no inter
+                bs_write1( s, 0 ); // no inter
+            }
+            else
+            {
+                bs_write1( s, 0 ); // Cr = Cb
+                scaling_list_write( s, sps, CQM_4PY );
+                scaling_list_write( s, sps, CQM_4PC );
+                bs_write1( s, 0 ); // Cr = Cb
+            }
             if( pps->b_transform_8x8_mode )
             {
                 scaling_list_write( s, sps, CQM_8IY+4 );
-                scaling_list_write( s, sps, CQM_8PY+4 );
+                if( sps->b_avcintra_4k )
+                    bs_write1( s, 0 ); // no inter
+                else
+                    scaling_list_write( s, sps, CQM_8PY+4 );
                 if( sps->i_chroma_format_idc == CHROMA_444 )
                 {
                     scaling_list_write( s, sps, CQM_8IC+4 );


### PR DESCRIPTION
Ok, so, Line 244, encoder/set.c, I removed the avcintra line and I replaced with the logic that picks the _hd one if it's below 200, so 50, 100, 200 and _4k if it's above that, so 300, 480.
Namely:

This one is gone:
 sps->b_avcintra = !!param->i_avcintra_class;

Those ones have been introduced:
    sps->b_avcintra_4k =  param->i_avcintra_class > 200;
    sps->b_avcintra_hd =  !!(param->i_avcintra_class && param->i_avcintra_class < 300);


In set.c Line 328 I also got rid of the i_avcintra_class, which no longer exists, as it's not divided between _hd and _4k, so:

This one is gone:
        bs_write1( s, sps->b_avcintra ); // seq_scaling_matrix_present_flag
        if( sps->b_avcintra )

And has been replaced by:
        bs_write1( s, sps->b_avcintra_hd ); // seq_scaling_matrix_present_flag
        if( sps->b_avcintra_hd )


Same goes for:

    int b_scaling_list = !sps->b_avcintra && sps->i_cqm_preset != X264_CQM_FLAT;

which has been replaced by:

    int b_scaling_list = !sps->b_avcintra_hd && sps->i_cqm_preset != X264_CQM_FLAT;



This should hopefully fix the compiling issue.