### PR TITLE
add aq-bias-strength parameter for dark-biased AQ

### DIFF
--- a/common/base.c
+++ b/common/base.c
@@ -451,6 +451,7 @@ REALIGN_STACK void x264_param_default( x264_param_t *param )
     param->rc.f_pb_factor = 1.3;
     param->rc.i_aq_mode = X264_AQ_VARIANCE;
     param->rc.f_aq_strength = 1.0;
+    param->rc.f_aq_bias_strength = 1.0;
     param->rc.f_aq_sensitivity = 10;
     param->rc.f_aq_ifactor = 1.0;
     param->rc.f_aq_pfactor = 1.0;
@@ -1670,6 +1671,8 @@ REALIGN_STACK int x264_param_parse( x264_param_t *p, const char *name, const cha
         p->rc.i_aq_mode = atoi(value);
     OPT("aq-strength")
         p->rc.f_aq_strength = atof(value);
+    OPT("aq-bias-strength")
+        p->rc.f_aq_bias_strength = atof(value);
     OPT("aq-sensitivity")
         p->rc.f_aq_sensitivity = atof(value);
     OPT("aq-ifactor")
@@ -2008,6 +2011,8 @@ char *x264_param2string( x264_param_t *p, int b_res )
             s += sprintf( s, " aq-factor=%.2f:%.2f:%.2f", p->rc.f_aq_ifactor,
                                                           p->rc.f_aq_pfactor,
                                                           p->rc.f_aq_bfactor );
+            if( p->rc.i_aq_mode == X264_AQ_AUTOVARIANCE_BIASED )
+                s += sprintf( s, ":%.2f", p->rc.f_aq_bias_strength );
 		}
         s += sprintf( s, " aq2=%d", p->rc.b_aq2 );
         if( p->rc.b_aq2 )

--- a/encoder/ratecontrol.c
+++ b/encoder/ratecontrol.c
@@ -573,7 +573,7 @@ void x264_adaptive_quant_frame( x264_t *h, x264_frame_t *frame, float *quant_off
             avg_adj_pow2 /= h->mb.i_mb_count;
             strength = h->param.rc.f_aq_strength * avg_adj;
             avg_adj = avg_adj - 0.5f * (avg_adj_pow2 - 14.f) / avg_adj;
-            bias_strength = h->param.rc.f_aq_strength;
+            bias_strength = h->param.rc.f_aq_strength * h->param.rc.f_aq_bias_strength;
         }
         else
 		{

--- a/x264.c
+++ b/x264.c
@@ -945,6 +945,7 @@ static void help( x264_param_t *defaults, int longhelp )
         "                                  - 3: Auto-variance AQ with bias to dark scenes\n", defaults->rc.i_aq_mode );
     H1( "      --aq-strength <float>   Reduces blocking and blurring in flat and\n"
         "                              textured areas. [%.1f]\n", defaults->rc.f_aq_strength );
+    H1( "      --aq-bias-strength <float> Adjust the bias to darks strength in AQ mode 3 [%.1f]\n", defaults->rc.f_aq_bias_strength );
     H1( "      --aq-sensitivity <float> \"Center\" of AQ curve. [%.1f]\n"
         "                                  -  5: most QPs are raised\n"
         "                                  - 10: good general-use sensitivity\n"
@@ -1458,6 +1459,7 @@ static struct option long_options[] =
     { "aq-pfactor",           required_argument, NULL, 0 },
     { "aq-bfactor",           required_argument, NULL, 0 },
     { "aq-mode",              required_argument, NULL, 0 },
+    { "aq-bias-strength",     required_argument, NULL, 0 },
     { "aq2-strength",         required_argument, NULL, 0 },
     { "aq2-sensitivity",      required_argument, NULL, 0 },
     { "aq2-ifactor",          required_argument, NULL, 0 },

--- a/x264.c
+++ b/x264.c
@@ -945,7 +945,7 @@ static void help( x264_param_t *defaults, int longhelp )
         "                                  - 3: Auto-variance AQ with bias to dark scenes\n", defaults->rc.i_aq_mode );
     H1( "      --aq-strength <float>   Reduces blocking and blurring in flat and\n"
         "                              textured areas. [%.1f]\n", defaults->rc.f_aq_strength );
-    H1( "      --aq-bias-strength <float> Adjust the bias to darks strength in AQ mode 3 [%.1f]\n", defaults->rc.f_aq_bias_strength );
+    H1( "      --aq-bias-strength <float> Adjust the bias to darks strength in AQ mode 3, effective bias is aq-strength * aq-bias-strength [%.1f]\n", defaults->rc.f_aq_bias_strength );
     H1( "      --aq-sensitivity <float> \"Center\" of AQ curve. [%.1f]\n"
         "                                  -  5: most QPs are raised\n"
         "                                  - 10: good general-use sensitivity\n"

--- a/x264.h
+++ b/x264.h
@@ -531,6 +531,7 @@ typedef struct x264_param_t
 
         int         i_aq_mode;      /* psy adaptive QP. (X264_AQ_*) */
         float       f_aq_strength;
+        float       f_aq_bias_strength; /* Fine-tune AQ mode 3 dark bias. */
         float       f_aq_sensitivity;
         float       f_aq_ifactor;
         float       f_aq_pfactor;


### PR DESCRIPTION
This is the exact same as the parameter in my x265 AQ mode 5 patch, which is also in your x265 mod, so I hope it shouldn't need any explanation.

(I also made a merge request upstream, but it hasn't been accepted yet.)